### PR TITLE
Updating Nokogiri to 1.10.8 to resolve CVE-2020-7595.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     forwardable-extended (2.6.0)
     html-pipeline (2.7.1)
       activesupport (>= 2)
-      nokogiri (>= 1.10.4)
+      nokogiri (>= 1.10.8)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jekyll (3.6.3)


### PR DESCRIPTION
This change updates the project's `nokogiri` dependency to 1.10.8 in `Gemfile.lock`.

This update resolves the vulnerability found in CVE-2020-7595.