### PR TITLE
Update kramdown to v2.3.1 to resolve CVE-2021-28834.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
       addressable (~> 2.4.0)
     jekyll-watch (1.5.1)
       listen (~> 3.0)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
     liquid (3.0.6)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)


### PR DESCRIPTION
This change updates a project dependency, `kramdown`, to version `2.3.1` to resolve an identified vulnerability with `jekyll` sites.