### PR TITLE
Update nokogiri dependency to v1.11.4.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     forwardable-extended (2.6.0)
     html-pipeline (2.7.1)
       activesupport (>= 2)
-      nokogiri (>= 1.10.8)
+      nokogiri (>= 1.11.4)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jekyll (3.6.3)


### PR DESCRIPTION
These changes update the project's `nokogiri` dependency to version `1.11.4` from `1.10.8` to resolve identified security vulnerabilities:
* [CVE-2019-20388](https://security.archlinux.org/CVE-2019-20388)
* [CVE-2020-24977](https://security.archlinux.org/CVE-2020-24977)
* [CVE-2021-3517](https://security.archlinux.org/CVE-2021-3517)
* [CVE-2021-3518](https://security.archlinux.org/CVE-2021-3518)
* [CVE-2021-3537](https://security.archlinux.org/CVE-2021-3537)
* [CVE-2021-3541](https://security.archlinux.org/CVE-2021-3541) 