### PR TITLE
Update nokogiri to latest patch version: 1.11.5.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multipart-post (2.0.0)
-    nokogiri (1.11.0.rc4)
+    nokogiri (1.11.5)
       mini_portile2 (~> 2.3.0)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)


### PR DESCRIPTION
These changes update the `nokogiri` project dependency to the latest patch version: `1.11.5`.