### PR TITLE
Update addressable to minor version to resolve GHSA-jxhc-q857-3j6g

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-sitemap (0.11.0)
-      addressable (~> 2.4.0)
+      addressable (~> 2.8.0)
     jekyll-watch (1.5.1)
       listen (~> 3.0)
     kramdown (2.3.1)


### PR DESCRIPTION
These changes update the `addressable` project dependency to `v2.8.0`, which resolves the identified vulnerability `GHSA-jxhc-q857-3j6g`.