### PR TITLE
Update nokogiri version to resolve CVE-2021-30560 & CVE-2022-23308.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     forwardable-extended (2.6.0)
     html-pipeline (2.7.1)
       activesupport (>= 2)
-      nokogiri (>= 1.12.5)
+      nokogiri (1.13.2)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jekyll (3.6.3)


### PR DESCRIPTION
These changes update the `nokogiri` project dependency to `1.13.2`, which resolves the identified vulnerabilities CVE-2021-30560 & CVE-2022-23308.